### PR TITLE
Suhwan2004/feature/dev 73 edit calender page

### DIFF
--- a/Client/src/features/Bookmark/BookmarkSlice.js
+++ b/Client/src/features/Bookmark/BookmarkSlice.js
@@ -1,8 +1,9 @@
 /* eslint-disable no-param-reassign */
 import { createSlice } from '@reduxjs/toolkit';
+import { PURGE } from 'redux-persist';
 
 const initialState = {
-  bookmarkSet: new Set(),
+  bookmarkArr: [],
 };
 
 export const BookmarkSlice = createSlice({
@@ -11,21 +12,24 @@ export const BookmarkSlice = createSlice({
   reducers: {
     addBookmark: (state, actions) => {
       const { postId } = actions.payload;
-      state.bookmarkSet.add(postId);
+      state.bookmarkArr.push(postId);
     },
 
     setBookmark: (state, actions) => {
       const { bookmarkList } = actions.payload;
-      state.bookmarkSet = new Set(bookmarkList);
+      state.bookmarkArr = [...bookmarkList];
     },
 
     deleteBookmark: (state, actions) => {
       const { postId } = actions.payload;
-      state.bookmarkSet.delete(postId);
+      state.bookmarkArr = state.bookmarkArr.filter((cur) => cur !== postId);
     },
 
     clearBookmark: (state) => {
-      state.bookmarkSet.clear();
+      state.bookmarkArr = [];
+    },
+    extraReducers: (builder) => {
+      builder.addCase(PURGE, () => initialState);
     },
   },
 });

--- a/Client/src/pages/Post/PostCalendar/PostCalendar.jsx
+++ b/Client/src/pages/Post/PostCalendar/PostCalendar.jsx
@@ -152,29 +152,36 @@ const filterEventPost = (data, bookmark, option, isBookmark) =>
     let bool = true; // filter에 통과하는 post인지 여부.
 
     // 북마크 필터가 되어 있을 시에, 현재 이 글이 북마크가 안되어 있는 글이라면 bool = false
-    if (isBookmark && !bookmark.bookmarkSet.has(curData._id)) {
+    if (isBookmark && !bookmark.has(curData._id)) {
       bool = false;
     }
 
-    const filteringTag = Object.values(option.tag).reduce(
-      (acc, cur) => [...acc, ...cur],
-      [],
-    );
+    const filteringTag = Object.values(option.tag);
+
+    let transArr = [];
+    for (let i = 0; i < filteringTag.length; i += 1) {
+      transArr = [...transArr, ...filteringTag[i]];
+    }
+
+    transArr = transArr.reduce((acc, cur) => [...acc, cur.code], []);
+
     const curTag = curData.postTag;
 
-    if (
-      filteringTag.length !== 0 ||
-      filteringTag.length !== curTag.length ||
-      !bool
-    ) {
+    // 조건이 없으면 그냥 뒤를 볼 필요 없이 반환
+    // 조건이 있으면 길이비교
+    if (transArr.length === 0) {
+      return bool;
+    }
+    if (transArr.length !== curTag.length || !bool) {
+      bool = false;
       return bool;
     }
 
-    filteringTag.sort((a, b) => a - b);
+    transArr.sort((a, b) => a - b);
     curTag.sort((a, b) => a - b);
 
-    for (let i = 0; i < filteringTag.length; i += 1) {
-      if (filteringTag[i] !== curTag[i]) {
+    for (let i = 0; i < transArr.length; i += 1) {
+      if (transArr[i] !== curTag[i]) {
         bool = false;
         break;
       }
@@ -187,7 +194,11 @@ function PostCalendar() {
   const curDate = new Date();
   const navigate = useNavigate();
   const dispatch = useDispatch();
-  const bookmark = useSelector(selectBookmark);
+
+  const { bookmarkArr } = useSelector(selectBookmark);
+  const bookmark = new Set();
+  bookmarkArr.forEach((cur) => bookmark.add(cur));
+
   const [curYear, setCurYear] = useState(curDate.getFullYear());
   const [curMonth, setCurMonth] = useState(curDate.getMonth() + 1);
   const [openModal, setOpenModal] = useState(false);
@@ -211,7 +222,10 @@ function PostCalendar() {
   const [modalPage, setModalPage] = useState(1);
   const localizer = momentLocalizer(moment);
   const handleClickEvent = () => setOpenModal(true);
-  const handleCloseModal = () => setOpenModal(false);
+  const handleCloseModal = () => {
+    setModalPage(1);
+    setOpenModal(false);
+  };
   moment.locale('ko-KR');
 
   // 달이 변화했거나, navigate 발생 시 useEffect를 거쳐야 한다.
@@ -231,7 +245,7 @@ function PostCalendar() {
       const { code } = apiRes.data;
       switch (apiRes.data.status) {
         case 'success':
-          setScheduleData(apiRes.data.data.post);
+          setScheduleData(apiRes.data.simplePostDataList);
           break;
         case 'fail':
           commonFailRes(dispatch, persistor, navigate, code);
@@ -289,6 +303,8 @@ function PostCalendar() {
         setModalPage={setModalPage}
         handleClose={handleCloseModal}
         scheduleData={scheduleData}
+        option={option}
+        isBookmark={isBookmark}
       />
       <Calendar
         localizer={localizer}
@@ -342,6 +358,8 @@ function PostcalendarModal(props) {
     handleClose,
     scheduleData,
     bookmark,
+    isBookmark,
+    option,
   } = props;
   const navigate = useNavigate();
   const dispatch = useDispatch();
@@ -353,7 +371,7 @@ function PostcalendarModal(props) {
     // 특정 postCard의 bookmark 버튼을 눌렀을 경우
     if (currentBookMark) {
       let apiRes;
-      if (bookmark.bookmarkSet.has(currentCard.id)) {
+      if (bookmark.has(currentCard.id)) {
         apiRes = await patchRemoveBookmark(currentCard.id);
       } else {
         apiRes = await postAddBookmark(currentCard.id);
@@ -388,8 +406,20 @@ function PostcalendarModal(props) {
   if (scheduleData.length === 0) return <div />;
 
   const currentPageScheduleData = [];
-  for (let i = 0; i < scheduleData.length; i += 5) {
-    currentPageScheduleData.push(scheduleData.slice(i, i + 5));
+
+  const filteredScheduleData = filterEventPost(
+    scheduleData,
+    bookmark,
+    option,
+    isBookmark,
+  );
+
+  if (filteredScheduleData.length <= 5) {
+    currentPageScheduleData.push(filteredScheduleData);
+  } else {
+    for (let i = 0; i < filteredScheduleData.length; i += 5) {
+      currentPageScheduleData.push(filteredScheduleData.slice(i, i + 5));
+    }
   }
   return (
     <Modal open={openModal} onClose={handleClose}>
@@ -407,7 +437,7 @@ function PostcalendarModal(props) {
           <Pagination
             count={currentPageScheduleData.length}
             page={modalPage}
-            onChange={(e, value) => setModalPage(value)}
+            onChange={(_e, value) => setModalPage(value)}
           />
         </Stack>
       </StyledModalWrapper>
@@ -453,11 +483,11 @@ const StyledModalWrapper = styled(Stack)`
 
 function CustomModalCard(props) {
   const { schedule, bookmark } = props;
-
   const currentCardTags = schedule.postTag.reduce(
-    (acc, cur) => [...acc, ...cur.tags],
+    (acc, cur) => [...acc, cur],
     [],
   );
+
   return (
     <StyledCard id={schedule._id}>
       <CardContent>
@@ -466,7 +496,7 @@ function CustomModalCard(props) {
             <Typography variant="h5" noWrap>
               {`행사명 : ${schedule.postTitle}`}
             </Typography>
-            {bookmark.bookmarkSet.has(schedule._id) ? (
+            {bookmark.has(schedule._id) ? (
               <BookmarkIcon />
             ) : (
               <BookmarkBorderIcon />

--- a/Client/src/pages/Post/PostCalendar/PostCalendar.jsx
+++ b/Client/src/pages/Post/PostCalendar/PostCalendar.jsx
@@ -321,10 +321,11 @@ function PostCalendar() {
             setIsBookmark,
           }),
         }}
-        popupOffset={2}
+        onDrillDown={handleClickEvent}
         eventPropGetter={CustomEventPropGetter}
         events={createPostCalendarEvents()}
         onSelectEvent={handleClickEvent}
+        drilldownView="null"
       />
     </StyledStack>
   );

--- a/Client/src/pages/Post/PostCalendar/PostCalendar.jsx
+++ b/Client/src/pages/Post/PostCalendar/PostCalendar.jsx
@@ -437,7 +437,7 @@ function PostcalendarModal(props) {
           <Pagination
             count={currentPageScheduleData.length}
             page={modalPage}
-            onChange={(_e, value) => setModalPage(value)}
+            onChange={(e, value) => setModalPage(value)}
           />
         </Stack>
       </StyledModalWrapper>

--- a/Client/src/pages/SignIn/SignIn.jsx
+++ b/Client/src/pages/SignIn/SignIn.jsx
@@ -25,6 +25,7 @@ import { commonFailRes, commonErrorRes } from '../../utils/commonApiRes';
 import { CommonTextField, CommonPaper } from '../../components';
 import { signinUser, selectUser } from '../../features/User/UserSlice';
 import { persistor } from '../../store';
+import { setBookmark } from '../../features/Bookmark/BookmarkSlice';
 
 function SignIn() {
   const { isSignin } = useSelector(selectUser);
@@ -92,6 +93,8 @@ function SignIn() {
             userRoleCd: payload.userRoleCd,
           }),
         ); // store에 정보 저장.
+
+        dispatch(setBookmark({ bookmarkList: apiRes.data.data.bookmarkList }));
         navigate('/', { replace: true }); // redirect to home
         break;
       case 'fail':

--- a/Client/src/store/persistedReducer.js
+++ b/Client/src/store/persistedReducer.js
@@ -8,7 +8,7 @@ import Bookmark from '../features/Bookmark/BookmarkSlice';
 const persistConfig = {
   key: 'root',
   storage,
-  whitelist: ['User'],
+  whitelist: ['User', 'Bookmark'],
 };
 
 const rootReducer = combineReducers({


### PR DESCRIPTION
## 이슈 키 목록
DEV-73

### 작업내역

ISSUE https://github.com/CalenDev/calendev/issues/48

- bookmarkSlice의 bookmarkSet을 bookmarkArr로 변경
   - Redux에서 new Set 활용시, 로직이 올바르게 실행되지 않던 이슈가 발생했었습니다.
   - 현재는 배열로 변경했고, 기존에 Set 자료구조를 사용하는 이점을 얻기 위해 bookmarkArr를 사용하는 파일에서는 bookmarkArr를 통해 hashSet을 만들어서 사용합니다.

- 캘린더의 + 4 more을 누르면 잘못된 뷰를 렌더링 하는 것을 수정했습니다.
  - 현재는 정상적으로 모달을 보여줍니다.

- 로그인 시, boomarkList를 받아서 상태관리하는 것을 추가했습니다.
  - 로그아웃 시에, 정상적으로 bookmarkSlice가 초기화 되도록 로직도 추가했습니다. 

- 모달의 로직 부분을 정상적으로 수정했습니다.

- 특정 태그 또는 북마크 보기등의 필터링을 최신 데이터 표준에 맞게 수정했습니다.


## 체크리스트
- [x]  Merge 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

## 추가할 사항
-[ ] 
